### PR TITLE
Add JS injection warning to eval

### DIFF
--- a/variables/eval.md
+++ b/variables/eval.md
@@ -24,6 +24,35 @@ would result in
 
 > Script execution timed out.
 
+## A warning about command input
+
+Variables substituted inside of the Eval variable are treated as raw JavaScript. 
+Because of this, extra care should be taken when using variables inside of Eval.
+
+> !addcom !upper $(eval "@$(user), " + "$(query)".toUpperCase())
+
+At first glance, this command works as expected:
+
+> User: !upper lulw
+Nightbot: @User, LULW
+
+However, a malicious user could use this command in combination with Nightbot's moderator level privileges to perform unintended actions.
+This can be especially risky when Nightbot is used in combination with other twitch bots.
+
+> User: !upper ";"!settitle Last stream ever!"//
+
+> Nightbot: !settitle Last stream ever!
+
+> OtherBot: @Nightbot, the title has been updated to "Last stream ever!"
+
+In order to avoid this, make use of the [QueryString](https://docs.nightbot.tv/variables/querystring) variable and JavaScript's [decodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent):
+
+> !addcom !upper $(eval "@$(user), " + decodeURIComponent("$(querystring)").toUpperCase())
+
+Or, if substituting a different variable, such as an [argument](https://docs.nightbot.tv/variables/arguments):
+
+> !addcom !upper $(eval "@$(user), " + decodeURIComponent("$(querystring $(3))").toUpperCase())
+
 ## Examples
 
 #### Generate a random number between 1 to 100


### PR DESCRIPTION
This PR adds a warning to the docs for the `eval` variable about how to safely use user input in commands. 